### PR TITLE
Preserve `$PS1` and return to the original directory

### DIFF
--- a/prm.sh
+++ b/prm.sh
@@ -206,5 +206,5 @@ if $(ls -a | grep ".active*" > /dev/null 2>&1); then
             rm $prm_dir/.active-$pid.tmp $prm_dir/.path-$pid.tmp $prm_dir/.prompt-$pid.tmp
         fi
     done
-    cd - >/dev/null 2>&1
 fi
+cd - >/dev/null 2>&1

--- a/prm.sh
+++ b/prm.sh
@@ -130,7 +130,7 @@ case "$1" in
                     fi
                     echo $2 > $prm_dir/.active-$$.tmp
                     if [ ! -e $prm_dir/.prompt-$$.tmp ]; then
-                        echo $PS1 > $prm_dir/.prompt-$$.tmp
+                        echo "$PS1" > $prm_dir/.prompt-$$.tmp
                         export PS1="[$2] $PS1"
                     else
                         export PS1="[$2] $(cat $prm_dir/.prompt-$$.tmp)"


### PR DESCRIPTION
The current version doesn't preserve `$PS1` exactly (removes leading/trailing whitespace) and always ends up in `~/.prm`.

Before:

```
lukas@bubbles:~$ prm start test
Starting project test
[test] lukas@bubbles:/tmp$ prm stop
Stopping project test
lukas@bubbles:~/.prm$pwd
```

After:

```
lukas@bubbles:~$ prm start test
Starting project test
[test] lukas@bubbles:/tmp$ prm stop
Stopping project test
lukas@bubbles:~$ pwd
```
