### PR TITLE
Made using 'cygpath' on Cygwin when editing optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ At present, prm supports `zsh`, as well as `bash`.
 For more information, see the [Wiki page on Zsh support](https://github.com/eivind88/prm/wiki/Zsh-support).
 
 Ostensibly, prm also [works](https://github.com/eivind88/prm/issues/27) under [Cygwin](https://cygwin.com).
+If your `$EDITOR` is set to a program external to Cygwin (ex: Sublime Text), you
+might want to add `export prm_use_cygpath=true` to your `.bashrc`/`.zshrc` to send
+the native Windows path to the editor.
 
 Regrettably, `fish` is not supported, because of syntax incompatibilities.
 See [this issue](https://github.com/eivind88/prm/issues/2) for some details.

--- a/prm.sh
+++ b/prm.sh
@@ -119,21 +119,13 @@ function check_project_name() {
 
 function edit_scripts() {
     # Open project start- and stop- scripts in $EDITOR
-    if [ $CI ] && [ $prm_bats_test_cygwin ]; then
-        uname="CYGWIN_NT-5.2-WOW64"
+    if [ $prm_use_cygpath ]; then
+        # Allow Cygwin users to use the full Windows path
+        # (ex: C:\\Users\\...) when editing the script.
+        $EDITOR `cygpath.exe -d "$prm_dir/$1/start.sh"` && $EDITOR `cygpath.exe -d "$prm_dir/$1/stop.sh"`
     else
-        uname=$(uname -s)
+        $EDITOR "$prm_dir/$1/start.sh" && $EDITOR "$prm_dir/$1/stop.sh"
     fi
-    case "$uname" in
-        CYGWIN*|MINGW32*|MSYS*)
-            #Cygwin
-            $EDITOR `cygpath.exe -d "$prm_dir/$1/start.sh"` && $EDITOR `cygpath.exe -d "$prm_dir/$1/stop.sh"`
-            ;;
-        *)
-            #OS X/Linux/BSD/etc.
-            $EDITOR "$prm_dir/$1/start.sh" && $EDITOR "$prm_dir/$1/stop.sh"
-            ;;
-    esac
 }
 
 function cleanup() {

--- a/tests/prm.bats
+++ b/tests/prm.bats
@@ -56,7 +56,7 @@ load common
 
 @test "add option with arg adds project under Cygwin (Mock)" {
     # prm add <project name>
-    prm_bats_test_cygwin=true
+    prm_use_cygpath=true
     project_name="test-prj"
     run prm add $project_name
     [ "$status" -eq 0 ]
@@ -64,7 +64,7 @@ load common
     [ $(echo "${lines[1]}" | grep "cygpath.exe: command not found") ]
     [ "${lines[2]}" = "Added project $project_name" ]
     rm -rf "$prm_dir/$project_name"
-    unset $prm_bats_test_cygwin
+    unset $prm_use_cygpath
 }
 
 @test "add option with several args adds several projects" {
@@ -110,7 +110,7 @@ load common
 
 @test "edit option succeeds if project exists under Cygwin (Mock)" {
     # prm copy <old> <new>
-    prm_bats_test_cygwin=true
+    prm_use_cygpath=true
     project_name=exists
     mkdir -p "$prm_dir/$project_name"
     touch "$prm_dir/$project_name/start.sh" "$prm_dir/$project_name/stop.sh"
@@ -120,7 +120,7 @@ load common
     [ $(echo "${lines[1]}" | grep "cygpath.exe: command not found") ]
     [ "${lines[2]}" = "Copied project $project_name to new-prj" ]
     rm -rf "$prm_dir/$project_name" "$prm_dir/new-prj"
-    unset $prm_bats_test_cygwin
+    unset $prm_use_cygpath
 }
 
 @test "copy option fails when no new name is given" {
@@ -153,7 +153,7 @@ load common
 
 @test "edit option succeeds if project exists under Cygwin (Mock)" {
     # prm edit <project name>
-    prm_bats_test_cygwin=true
+    prm_use_cygpath=true
     project_name=exists
     mkdir -p "$prm_dir/$project_name"
     touch "$prm_dir/$project_name/start.sh" "$prm_dir/$project_name/stop.sh"
@@ -163,7 +163,7 @@ load common
     [ $(echo "${lines[1]}" | grep "cygpath.exe: command not found") ]
     [ "${lines[2]}" = "Edited project $project_name" ]
     rm -rf "$prm_dir/$project_name"
-    unset $prm_bats_test_cygwin
+    unset $prm_use_cygpath
 }
 
 @test "edit option succeeds if several project exist" {


### PR DESCRIPTION
This functionality (added in https://github.com/eivind88/prm/issues/27) broke 'edit' functionality for users that used editors installed in
Cygwin (ex: vim). Users with external editors (ex: SublimeText) can put
`export prm_use_cygpath=true` in their .bashrc/.zshrc