### PR TITLE
Added Makefile to support distribution through bpkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+PREFIX ?= /usr/local
+
+install:
+	cp prm.sh $(PREFIX)/bin

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,5 @@ PREFIX ?= /usr/local
 install:
 	@cp prm.sh $(PREFIX)/bin
 	@echo "prm installed in $(PREFIX)/bin/prm.sh"
+	@echo "Remember to add the following alias to your shell configuration file"
+	@echo "alias prm=\". $(PREFIX)/bin/prm.sh\""

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 PREFIX ?= /usr/local
 
-.PHONY = install
+.PHONY: install
 install:
 	@cp prm.sh $(PREFIX)/bin
 	@echo "prm installed in $(PREFIX)/bin/prm.sh"
-	@echo "Remember to add the following alias to your shell configuration file"
+	@echo "Remember to add the following alias to your shell configuration file."
 	@echo "alias prm=\". $(PREFIX)/bin/prm.sh\""
+
+.PHONY: uninstall
+uninstall:
+	@rm -f $(PREFIX)/bin/prm.sh
+	@echo "prm removed from $(Prefix)/BIn"
+	@echo "Remember to remove the alias from your shell configuration file."

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 PREFIX ?= /usr/local
 
+.PHONY = install
 install:
-	cp prm.sh $(PREFIX)/bin
+	@cp prm.sh $(PREFIX)/bin
+	@echo "prm installed in $(PREFIX)/bin/prm.sh"


### PR DESCRIPTION
With this Makefile, it is possible to install the shell script with [`bpkg`](https://github.com/bpkg/bpkg) directly from github. The following command is an example that installs the script from my fork.

```bash
sudo bpkg install -g dexpota/prm
```

It is possible to add support for `bpkg` distribution through a `package.json` file instead of a Makefile. I could add it too if you want me to.

On a side note, why did you choose to go with sourcing the script instead of calling it directly as an executable?